### PR TITLE
Update dependencies for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 langchain==0.1.4
-pandas==2.0.1
+pandas>=2.1.0
 tiktoken==0.4.0
 openai==0.27.2
 langchain_google_genai==0.0.4
-gradio==3.50.2
-datasets==2.15.0
-tiktoken==0.4.0
+gradio>=6.0.0
+datasets>=4.0.0
 func_timeout==4.3.5


### PR DESCRIPTION
- Upgrade pandas from 2.0.1 to >=2.1.0 (fixes compilation errors on Python 3.13)
- Upgrade gradio from 3.50.2 to >=6.0.0 (includes audioop-lts for Python 3.13)
- Upgrade datasets from 2.15.0 to >=4.0.0 (fixes HfFolder import error with newer huggingface_hub)